### PR TITLE
Workaround for Qt bug

### DIFF
--- a/src/AddItemDialog.hpp
+++ b/src/AddItemDialog.hpp
@@ -28,7 +28,9 @@
 #include <QDialog>
 #include "ui_additemdialog.h"
 #include <memory>
+#ifndef Q_MOC_RUN
 #include "plugins/ItemFactoryInterface.hpp"
+#endif
 #include <type_traits>
 
 namespace envire { namespace core {

--- a/src/AddItemDialog.hpp
+++ b/src/AddItemDialog.hpp
@@ -28,7 +28,7 @@
 #include <QDialog>
 #include "ui_additemdialog.h"
 #include <memory>
-#ifndef Q_MOC_RUN
+#if QT_VERSION >= 0x050000 || !defined(Q_MOC_RUN)
 #include "plugins/ItemFactoryInterface.hpp"
 #endif
 #include <type_traits>

--- a/src/EnvireGraphVisualizer.hpp
+++ b/src/EnvireGraphVisualizer.hpp
@@ -27,6 +27,7 @@
 #pragma once
 #include <unordered_map>
 #include <typeindex>
+#ifndef Q_MOC_RUN
 #include <vizkit3d/Vizkit3DPlugin.hpp>
 #include <vizkit3d/Vizkit3DWidget.hpp>
 #include <envire_core/graph/GraphTypes.hpp>
@@ -36,10 +37,13 @@
 #include <envire_core/items/Transform.hpp>
 #include <boost/uuid/uuid.hpp>
 #include <boost/functional/hash.hpp>
+#endif
 #include <memory>
 #include <unordered_map>
 #include <mutex>
+#ifndef Q_MOC_RUN
 #include <vizkit3d_plugin_information/Vizkit3dPluginInformation.hpp>
+#endif
 
 namespace envire { namespace core 
 {

--- a/src/EnvireGraphVisualizer.hpp
+++ b/src/EnvireGraphVisualizer.hpp
@@ -27,7 +27,7 @@
 #pragma once
 #include <unordered_map>
 #include <typeindex>
-#ifndef Q_MOC_RUN
+#if QT_VERSION >= 0x050000 || !defined(Q_MOC_RUN)
 #include <vizkit3d/Vizkit3DPlugin.hpp>
 #include <vizkit3d/Vizkit3DWidget.hpp>
 #include <envire_core/graph/GraphTypes.hpp>
@@ -41,7 +41,7 @@
 #include <memory>
 #include <unordered_map>
 #include <mutex>
-#ifndef Q_MOC_RUN
+#if QT_VERSION >= 0x050000 || !defined(Q_MOC_RUN)
 #include <vizkit3d_plugin_information/Vizkit3dPluginInformation.hpp>
 #endif
 

--- a/src/EnvireVisualizerWindow.hpp
+++ b/src/EnvireVisualizerWindow.hpp
@@ -30,7 +30,7 @@
 #include <QMainWindow> 
 #include <QListWidgetItem>
 #include <memory>
-#ifndef Q_MOC_RUN
+#if QT_VERSION >= 0x050000 || !defined(Q_MOC_RUN)
 #include <envire_core/events/GraphEventDispatcher.hpp>
 #include <envire_core/graph/GraphTypes.hpp>
 #endif

--- a/src/EnvireVisualizerWindow.hpp
+++ b/src/EnvireVisualizerWindow.hpp
@@ -30,8 +30,10 @@
 #include <QMainWindow> 
 #include <QListWidgetItem>
 #include <memory>
+#ifndef Q_MOC_RUN
 #include <envire_core/events/GraphEventDispatcher.hpp>
 #include <envire_core/graph/GraphTypes.hpp>
+#endif
 #include <unordered_map>
 #include <mutex>
 #include <chrono>

--- a/src/plugins/ItemManipulatorFactoryInterface.hpp
+++ b/src/plugins/ItemManipulatorFactoryInterface.hpp
@@ -25,7 +25,7 @@
 //
 
 #pragma once
-#ifndef Q_MOC_RUN
+#if QT_VERSION >= 0x050000 || !defined(Q_MOC_RUN)
 #include <envire_core/items/ItemBase.hpp>
 #include <envire_core/graph/EnvireGraph.hpp>
 #include <envire_core/graph/TreeView.hpp>

--- a/src/plugins/ItemManipulatorFactoryInterface.hpp
+++ b/src/plugins/ItemManipulatorFactoryInterface.hpp
@@ -25,9 +25,11 @@
 //
 
 #pragma once
+#ifndef Q_MOC_RUN
 #include <envire_core/items/ItemBase.hpp>
 #include <envire_core/graph/EnvireGraph.hpp>
 #include <envire_core/graph/TreeView.hpp>
+#endif
 class QWidget;
 
 

--- a/viz/EnvireVisualizerWidget.hpp
+++ b/viz/EnvireVisualizerWidget.hpp
@@ -27,10 +27,14 @@
 #ifndef envire_visualizer_EnvireVisualizerWidget_H
 #define envire_visualizer_EnvireVisualizerWidget_H
 
+#ifndef Q_MOC_RUN
 #include <boost/noncopyable.hpp>
+#endif
 #include <vizkit3d/Vizkit3DPlugin.hpp>
 #include <osg/Geode>
+#ifndef Q_MOC_RUN
 #include <envire_core/graph/EnvireGraph.hpp>
+#endif
 
 namespace vizkit3d
 {

--- a/viz/EnvireVisualizerWidget.hpp
+++ b/viz/EnvireVisualizerWidget.hpp
@@ -27,12 +27,12 @@
 #ifndef envire_visualizer_EnvireVisualizerWidget_H
 #define envire_visualizer_EnvireVisualizerWidget_H
 
-#ifndef Q_MOC_RUN
+#if QT_VERSION >= 0x050000 || !defined(Q_MOC_RUN)
 #include <boost/noncopyable.hpp>
 #endif
 #include <vizkit3d/Vizkit3DPlugin.hpp>
 #include <osg/Geode>
-#ifndef Q_MOC_RUN
+#if QT_VERSION >= 0x050000 || !defined(Q_MOC_RUN)
 #include <envire_core/graph/EnvireGraph.hpp>
 #endif
 


### PR DESCRIPTION
I could not build this project because of a bug that was very similar to this one: https://stackoverflow.com/questions/15455178/qt4-cgal-parse-error-at-boost-join

This is a workaround for the bug: while Qt MOC is running, boost includes are excluded.